### PR TITLE
add test for blackjack 'stand' loop

### DIFF
--- a/msl/runtime/eval_test.go
+++ b/msl/runtime/eval_test.go
@@ -116,3 +116,10 @@ func TestCompare01(t *testing.T) {
 		}
 	}
 }
+
+func TestTimtomsBustedWhileLoop(t *testing.T){
+	if v := eval("%dealertotal [ $+ [ israel ] ] <= 16"); v != "false" {
+		t.Errorf("%q: israel shouldn't exist, but Gamme thinks it does? - ",v)
+	}
+
+}


### PR DESCRIPTION
https://github.com/gamme/TIMTOM-irc-bot/blob/master/TIMTOM.txt#L2423 this while loop seems to run one time too many after dealer busts. That is a FACT backed by empirical observations in the chat laboratory:
```
06:58:33                                @TIMTOM | Ok, mr_scientist, you got 4. This gives you 11. Do you wish to hit or stand?
06:58:34                          @mr_scientist | hit
06:58:35                                @TIMTOM | Ok, mr_scientist, you got 4. This gives you 15. Do you wish to hit or stand?
06:58:37                          @mr_scientist | stand
06:58:37                                @TIMTOM| Alright-o, mr_scientist! Dealer has 8 and 6. So that's 14. I better hit!
06:58:38                                @TIMTOM | Dealer gets 8. So that's 22. WHOOPS!! I busted! LOL :D :D Dealer pays $5000. Congratulations mr_scientist!
06:58:38                                @TIMTOM | Dealer gets Queen. So that's 10. I better hit!
06:58:39                                @TIMTOM | Dealer gets Jack. So that's 20. I'll stay.
06:58:40                                @TIMTOM | Ah well, I won. I hate to have to do it to you, mr_scientist, but I'm going to have to take $0 from you and put it into the
                                                | pot. :( I hope you play again sometime and have better luck.
```
If this ever worked in mirc, then my guess is that mirc returns false for <= comparison with missing left side, while this interpreter coerces it to 0 and returns true. Or maybe it's because of the greedy voodoo bogey wogey whatever that you already test for in https://github.com/chzchzchz/sitbot/blob/master/msl/runtime/eval_test.go#L80 , I don't care I just want the bot to work normal and I'm not learning msl or golang or pegging for this.